### PR TITLE
Fix useragent string handling for Firefox.

### DIFF
--- a/config/useragents.sql
+++ b/config/useragents.sql
@@ -4,9 +4,9 @@ INSERT INTO `useragents` (`name`, `engine`, `version`, `active`, `current`, `pop
 
 ('Chrome', 'chrome', '.*', 1, 1, 1, 1, 0, 0),
 
-('Firefox 3.5', 'gecko', '^1.9.1[0-9.]*$', 1, 0, 0, 1, 0, 0),
-('Firefox 3.6', 'gecko', '^1.9.2[0-9.]*$', 1, 0, 1, 1, 0, 0),
-('Firefox 4.0', 'gecko', '^2.0.', 1, 1, 1, 1, 0, 0),
+('Firefox 3.5', 'gecko', '^1.9.1', 1, 0, 0, 1, 0, 0),
+('Firefox 3.6', 'gecko', '^1.9.2', 1, 0, 1, 1, 0, 0),
+('Firefox 4.0', 'gecko', '^2.0', 1, 1, 1, 1, 0, 0),
 
 ('Internet Explorer 6', 'msie', '^6.', 1, 0, 1, 1, 0, 0),
 ('Internet Explorer 7', 'msie', '^7.', 1, 0, 1, 1, 0, 0),


### PR DESCRIPTION
This minor change makes TestSwarm less strict about the useragent string for Firefox. In particular, it makes it possible for production builds of Firefox 4 to be recognized as such (they're currently not).
