### PR TITLE
Add latest Opera and Firefox to database

### DIFF
--- a/config/useragents.sql
+++ b/config/useragents.sql
@@ -17,6 +17,7 @@ INSERT INTO `useragents` (`name`, `engine`, `version`, `active`, `current`, `pop
 ('Opera 10.6x', 'presto', '^2.6.', 1, 0, 1, 0, 0, 0),
 ('Opera 11.0x', 'presto', '^2.7.', 1, 1, 1, 1, 0, 0),
 ('Opera 11.1x', 'presto', '^2.8.', 1, 1, 1, 1, 0, 0),
+('Opera 11.5x', 'presto', '^2.9.', 1, 1, 1, 1, 0, 0),
 
 ('Safari 4.0', 'webkit', '^531.', 1, 0, 1, 1, 0, 0),
 ('Safari 5.0', 'webkit', '^533.', 1, 1, 1, 1, 0, 0),


### PR DESCRIPTION
Just a couple small changes to `useragents.sql` that add Opera 11.1x and Firefox 5.0 to the user agents table.
