### PR TITLE
Adding HP TouchPad user-agent string (webOS 3.0).

### DIFF
--- a/config/useragents.sql
+++ b/config/useragents.sql
@@ -40,5 +40,6 @@ INSERT INTO `useragents` (`name`, `engine`, `version`, `active`, `current`, `pop
 ('S60 5.0', 's60', '^5.0$', 1, 1, 0, 0, 0, 1),
 
 ('webOS Browser 1.4', 'webos', '^1.4', 1, 1, 0, 0, 0, 1),
+('webOS Browser 3.0', 'hpwos', ^3.0', 1, 1, 0, 0, 0, 1),
 
 ('Windows Mobile 7', 'winmo', '^7.', 1, 1, 0, 0, 0, 1);


### PR DESCRIPTION
With the release of the HP TouchPad, webOS 3.0 is now available for testing.
