### PR TITLE
presto 2.10 is opera 10.6 not 10.5

### DIFF
--- a/config/useragents.sql
+++ b/config/useragents.sql
@@ -21,7 +21,7 @@ INSERT INTO `useragents` (`name`, `engine`, `version`, `active`, `current`, `pop
 
 ('Opera 11.1x', 'presto', '^2.8.', 1, 1, 1, 1, 0, 0),
 ('Opera 11.5x', 'presto', '^2.9.', 1, 1, 1, 1, 0, 0),
-('Opera 11.5x', 'presto', '^2.10.', 1, 1, 1, 1, 0, 0),
+('Opera 11.6x', 'presto', '^2.10.', 1, 1, 1, 1, 0, 0),
 
 ('Safari 4.0', 'webkit', '^531.', 1, 0, 0, 1, 0, 0),
 ('Safari 5.0', 'webkit', '^533.', 1, 0, 0, 1, 0, 0),


### PR DESCRIPTION
typo in a previous commit
