### PR TITLE
Replace unresponsive testswarm.com with swarm.jquery.org

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 TestSwarm v0.2.0pre - Distributed continuous integration for JavaScript.
 
-http://testswarm.com/
+http://swarm.jquery.org/
 
 DISCUSSION
 

--- a/scripts/testswarm-dojo.pl.txt
+++ b/scripts/testswarm-dojo.pl.txt
@@ -7,7 +7,7 @@ use warnings;
 
 # The location of the TestSwarm that you're going to run against.
 
-my $SWARM = "http://testswarm.com";
+my $SWARM = "http://swarm.jquery.org";
 my $SWARM_INJECT = "/js/inject.js";
 
 # Your TestSwarm username.

--- a/scripts/testswarm-mootools.pl.txt
+++ b/scripts/testswarm-mootools.pl.txt
@@ -7,7 +7,7 @@ use warnings;
 
 # The location of the TestSwarm that you're going to run against.
 
-my $SWARM = "http://testswarm.com";
+my $SWARM = "http://swarm.jquery.org";
 my $SWARM_INJECT = "/js/inject.js";
 
 # Your TestSwarm username.

--- a/scripts/testswarm-prototype.pl.txt
+++ b/scripts/testswarm-prototype.pl.txt
@@ -4,7 +4,7 @@
 
 # The location of the TestSwarm that you're going to run against.
 
-my $SWARM = "http://testswarm.com";
+my $SWARM = "http://swarm.jquery.org";
 my $SWARM_INJECT = "/js/inject.js";
 
 # Your TestSwarm username.


### PR DESCRIPTION
Found a few remaining references to [testswarm.com](http://testswarm.com/), replaced with [swarm.jquery.org](http://swarm.jquery.org/).
- Already updated the [TestSwarm wiki](https://github.com/jquery/testswarm/wiki).
- The [project url on github](https://github.com/jquery/testswarm) needs to be updated too.
