### PR TITLE
Do not strip trailing slash from the root path under nginx.

### DIFF
--- a/config/sample-nginx.conf
+++ b/config/sample-nginx.conf
@@ -21,7 +21,7 @@ server {
 
 		if ( !-f $request_filename ) {
 			# Remove any trailing slash (redirect)
-			rewrite ^(.*)/$ $1 permanent;
+			rewrite ^(.+)/$ $1 permanent;
 
 			# Pretty action-urls (rewrite, no redirect)
 			rewrite ^/([a-z]*)$ /index.php?action=$1;


### PR DESCRIPTION
The nginx config rule for stripping trailing slashes currently causes a 301 redirect to a blank location when requesting the root resource (`/`). This commit fixes that by only stripping slashes that have 1 or more preceeding characters.
