### PR TITLE
Issue #264 - Don't override QUnit.done

### DIFF
--- a/js/inject.js
+++ b/js/inject.js
@@ -223,13 +223,13 @@
 				return typeof QUnit !== 'undefined';
 			},
 			install: function () {
-				QUnit.done = function ( results ) {
+				QUnit.done(function ( results ) {
 					submit({
 						fail: results.failed,
 						error: 0,
 						total: results.total
 					});
-				};
+				});
 
 				QUnit.log = window.TestSwarm.heartbeat;
 				window.TestSwarm.heartbeat();


### PR DESCRIPTION
Rather than overriding QUnit.done, register a callback with it so that
it continues to function normally.  Overriding it was causing the
behavior of QUnit.done to differ from what was specified in the API docs
which caused some weird behavior with other plugins like QUnit.Composite.

Fixes #264.
