### PR TITLE
Clarify setup instructions for non-root installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ may work as well.
 
 1. *For Apache:*<br/>
    Copy `config/sample-.htaccess` to `.htaccess`.<br/>
-   To run TestSwarm from a non-root directory, set `web.contextpath` to the
+   To run TestSwarm from a non-root directory, set `web.contextpath` in `localSettings.json` to the
    correct path from the web root and update RewriteBase in `.htaccess`.
    Verify that `.htaccess` is working properly by opening a page other than the HomePage (e.g.
    `/testswarm/projects`) in your browser.<br/>Required Apache configuration:<br/>


### PR DESCRIPTION
When I was setting up an instance of testswarm in a non-root directory earlier today, it wasn't clear from the instructions that web.contextpath was set in localSettings.json.  The instructions made it seem like it's something to be done in .htaccess
