### PR TITLE
Fix site_url in sql install script, a BLOB cannot have a default value

### DIFF
--- a/config/tables.sql
+++ b/config/tables.sql
@@ -13,7 +13,7 @@ CREATE TABLE `projects` (
 
   -- URL pointing to a page with more information about this project
   -- (Optional field, can be empty).
-  `site_url` blob NOT NULL default '',
+  `site_url` blob,
 
   -- Salted hash of password (see LoginAction::comparePasswords).
   `password` tinyblob NOT NULL,


### PR DESCRIPTION
site_url seems optionnal
    BLOB cannot have default values and errors on some systems when installing
    see http://dev.mysql.com/doc/refman/5.5/en/blob.html
