### PR TITLE
Issue #274 - Add some documentation around projects and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ may work as well.
    cleaning duties such as making timed-out runs available again.<br/>
    `* * * * * curl -s http://swarm.example.org/api.php?action=cleanup > /dev/null`
 
+1. [Create projects](https://github.com/jquery/testswarm/blob/master/scripts/README.md#create-projects) then [submit jobs](https://github.com/jquery/testswarm/blob/master/scripts/addjob/README.md)
+
 
 Get involved
 ---------------------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,17 @@
+Maintenance scripts
+===================
+
+Create projects
+---------------
+
+Before being able to submit jobs (via web interface or api),
+you must first create projects that will give you auth credentials
+to be used when requesting testswarm instance.
+
+```shell
+php scripts/manageProject.php --create --id="jQuery" --display-title="jQuery.is(awesome)"
+```
+
+[Add jobs](https://github.com/jquery/testswarm/blob/master/scripts/addjob/README.md)
+---------
+

--- a/scripts/addjob/README.md
+++ b/scripts/addjob/README.md
@@ -4,6 +4,8 @@ from TestSwarms' perspective.
 
 For more information about the fields, view the AddjobPage in your browser.
 
+Please create a project before submitting jobs.
+
 ## Test suite runs
 
 Before you can submit a job you has to have an actual test suite. Presumably you already have this but there are a few requirements that you need to check and implement as needed. Currently TestSwarm supports the following unit test frameworks:


### PR DESCRIPTION
Using testswarm is very confusing right now because there's no
informtion on how to create projects and get the very important
credentials back..

Fixes #274
