### PR TITLE
Provide an X-Frame-Option hint in example htaccess

### DIFF
--- a/config/sample-.htaccess
+++ b/config/sample-.htaccess
@@ -7,7 +7,8 @@ Deny from all
 </Files>
 
 # Force X-Frame-Options to a bad value to overcome in-place reverse proxy configurations
-# Header set X-Frame-Options GOFORIT
+# we set a bad value (it should be "allow-from") so that browsers will ignore it
+# Header set X-Frame-Options "Allow from"
 
 RewriteEngine On
 RewriteBase /testswarm


### PR DESCRIPTION
I came with a case where the hosted testswarm was behind a reverse proxy
that was setting X-Frame-Option DENY/SAMEORIGIN by default

I thought it would be good to provide newcomers an hint in example
htaccess that could override reverse proxy value.

Maybe we should set it by default rather than having it commented.
