### PR TITLE
Restoring functionality with QUnit 2.x.

### DIFF
--- a/js/inject.js
+++ b/js/inject.js
@@ -232,7 +232,7 @@
 					});
 				});
 
-				QUnit.log = window.TestSwarm.heartbeat;
+				QUnit.log(window.TestSwarm.heartbeat);
 				window.TestSwarm.heartbeat();
 
 				window.TestSwarm.serialize = function() {


### PR DESCRIPTION
Fixes #313. 

You can see that with QUnit2, you can no longer do `QUnit.log = function() {};`, instead you need to do `QUnit.log(function() {});`. **Migration Guide:** https://qunitjs.com/upgrade-guide-2.x/#replace-qunit-log-callback-with-qunit-log-callback-for-all-reporting-callbacks

As I was looking for a way to make this backwards compatible I discovered that they have seemingly always supported `QUnit.log(function() {});`. You can see in QUnit 1.0 here: https://github.com/qunitjs/qunit/blob/v1.0.0/qunit/qunit.js#L684-L703 . 

I tested this change with `QUnit 2.1.0` and `QUnit 1.23.1`, it worked with both versions. I did not go all the way back to `QUnit 1.0.0`, but I am confident that this change would be backwards compat that far.