### PR TITLE
build: Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Michał Gołębiowski-Owczarek <m.goleb@gmail.com>


### PR DESCRIPTION
This makes all @mgol's entries to be collapsed. Otherwise, due to the ambiguity
of the "ę" representation in Unicode - either as a separate letter or as "e"
plus Unicode "Combining Ogonek (U+0328)" - some of my commits are treated as
separate.